### PR TITLE
Stitching ner

### DIFF
--- a/bert_experiments/find_head_masks.py
+++ b/bert_experiments/find_head_masks.py
@@ -26,7 +26,7 @@ import numpy as np
 import torch
 from tqdm import tqdm
 from finetune import compute_ner_metrics
-
+from data import WIKIANN_NAME
 
 def entropy(p):
     """ Compute the entropy of a probability distribution """
@@ -96,7 +96,7 @@ def compute_heads_importance(args,
             head_importance += head_mask.grad.abs().detach()
 
         # Also store our logits/labels if we want to compute metrics afterwards
-        if task_name=='wikiann':
+        if task_name==WIKIANN_NAME:
             logits = logits.detach().cpu() # batch_size, max_seq_length, labels
             tmp_preds = torch.argmax(logits,axis=-1) # batch_size, max_seq_length
             tmp_preds = tmp_preds.detach().cpu().tolist()
@@ -144,7 +144,7 @@ def compute_heads_importance(args,
     return attn_entropy, head_importance, preds, labels
 
 def metric_score(task_name, preds, labels):
-    if task_name=='wikiann':
+    if task_name==WIKIANN_NAME:
         dict_original_score = compute_ner_metrics(labels, preds)
         original_score = dict_original_score['f1']
     else:    

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -4,7 +4,8 @@ from .pawsx import PawsXDataset
 from .xnli import XNLIDataset
 from .wikiann import WikiannDataset
 
-ALLOWED_DATASETS = ['marc', 'paws-x', 'xnli','wikiann']
+WIKIANN_NAME = 'wikiann'
+ALLOWED_DATASETS = ['marc', 'paws-x', 'xnli',WIKIANN_NAME]
 
 
 def get_dataset(dataset_name: str, *args, **kwargs) -> ClassificationDataset:
@@ -17,7 +18,7 @@ def get_dataset(dataset_name: str, *args, **kwargs) -> ClassificationDataset:
         return PawsXDataset(*args, **kwargs)
     elif name == 'xnli':
         return XNLIDataset(*args, **kwargs)
-    elif name == 'wikiann':
+    elif name == WIKIANN_NAME:
         return WikiannDataset(*args, **kwargs)
     else:
         raise NameError(f"{dataset_name} is unknown.")

--- a/data/wikiann.py
+++ b/data/wikiann.py
@@ -3,18 +3,17 @@ import torch
 
 from .general import ClassificationDataset
 
-
 class WikiannDataset(ClassificationDataset):
 
     name = 'wikiann'
-    n_classes = 2
+    n_classes = 7
 
     def __init__(self,
                  tokenizer: AutoTokenizer,
                  lang: str = None,
                  split: str = 'train',
-                 sample_n: int = 0):
-        super().__init__("wikiann", tokenizer, lang, split, sample_n)
+                 sample_n: int = 0,**kwargs):
+        super().__init__('wikiann', tokenizer, lang, split, sample_n, **kwargs)
 
     def _get_input(self, row: dict):
         return row['tokens']

--- a/eval.py
+++ b/eval.py
@@ -9,12 +9,14 @@ import torch
 from pathlib import Path
 import numpy as np
 from tqdm import tqdm
+from finetune import compute_ner_metrics
 from torch.utils.data import DataLoader
 from transformers import (AutoTokenizer,
                           AutoModelForSequenceClassification,
                           TrainingArguments,
                           DataCollatorWithPadding,
-                          Trainer)
+                          Trainer,
+                          DataCollatorForTokenClassification)
 import evaluate
 
 from data import get_dataset, ALLOWED_DATASETS, ALLOWED_LANGUAGES
@@ -60,6 +62,33 @@ def get_model_accuracy(model, dataset, batch_size, head_mask=None):
 
     return hits / total
 
+def get_model_f1(model, dataset, batch_size, head_mask=None):
+    data_loader = DataLoader(dataset,
+                             batch_size=batch_size,
+                             pin_memory=True,
+                             num_workers=4,
+                             drop_last=False,
+                             collate_fn=DataCollatorForTokenClassification(dataset.tokenizer))
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+   
+    if head_mask is not None:
+        head_mask = head_mask.to(device)
+
+    all_preds = []
+    all_labels = []
+    for batch in tqdm(data_loader, desc='Evaluation'):
+        batch = {k: v.to(device, non_blocking=True) for (k, v) in batch.items()}
+        if head_mask is not None:
+            batch.update({"head_mask": head_mask})
+        with torch.no_grad():
+            logits = model(**batch)[1]
+            preds = logits.detach().argmax(dim=-1)
+            all_preds.extend(preds.cpu().tolist()) # maybe dummy way to do it
+            all_labels.extend(batch['labels'].detach().cpu().tolist())
+     
+    f1 = compute_ner_metrics(all_labels, all_preds)
+    return f1
 
 def main(args):
 

--- a/finetune.py
+++ b/finetune.py
@@ -10,7 +10,7 @@ from transformers import (AutoTokenizer,
                           EarlyStoppingCallback, AutoModelForTokenClassification)
 import evaluate #we need !pip install seqeval
 
-from data import get_dataset, ALLOWED_DATASETS
+from data import get_dataset, ALLOWED_DATASETS, WIKIANN_NAME
 
 
 def compute_metrics():
@@ -54,7 +54,7 @@ def main(args):
     # Get model
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
-    if args.dataset == 'wikiann':
+    if args.dataset == WIKIANN_NAME:
         label_names = train.dataset.features["ner_tags"].feature.names
         id2label = {i: label for i, label in enumerate(label_names)}
         label2id = {v: k for k, v in id2label.items()}
@@ -81,7 +81,7 @@ def main(args):
                                       dataloader_num_workers=2,
                                       save_total_limit=1,
                                       fp16=True)
-    if args.dataset == 'wikiann':
+    if args.dataset == WIKIANN_NAME:
         trainer = Trainer(model,
                       training_args,
                       train_dataset=train,
@@ -133,5 +133,4 @@ if __name__ == "__main__":
                         help='Number of train samples. 0 means all.')
 
     args = parser.parse_args()
-
     main(args)

--- a/mask.py
+++ b/mask.py
@@ -14,7 +14,7 @@ import pickle
 from pathlib import Path
 from transformers import AutoTokenizer, AutoModelForSequenceClassification, DataCollatorWithPadding, AutoModelForTokenClassification, DataCollatorForTokenClassification
 
-from data import get_dataset, ALLOWED_LANGUAGES
+from data import get_dataset, ALLOWED_LANGUAGES, WIKIANN_NAME
 
 from bert_experiments import mask_heads
 
@@ -33,7 +33,6 @@ def get_dataloader(args, dataset_name, tokenizer, lang, collate_fn):
                              num_workers=4,
                              drop_last=True,
                              collate_fn=collate_fn)
-                             #DataCollatorWithPadding(tokenizer))
 
     return data_loader
 
@@ -51,7 +50,7 @@ def main(args):
 
         # Define data pipeline and pretrained model
         
-        if dataset_name == 'wikiann':
+        if dataset_name == WIKIANN_NAME:
             collate_fn = DataCollatorForTokenClassification(tokenizer=tokenizer)
             label_names = ['O', 'B-PER', 'I-PER', 'B-ORG', 'I-ORG', 'B-LOC', 'I-LOC']
             id2label = {i: label for i, label in enumerate(label_names)}

--- a/utils/affine_stitch.py
+++ b/utils/affine_stitch.py
@@ -38,7 +38,7 @@ class StitchNet(nn.Module):
         self.front_mask = torch.load(mask1).to(self.front_model.device)
         self.end_mask = torch.load(mask2).to(self.end_model.device)
 
-    def find_optimal_init(self, loader):
+    def find_optimal_init(self, loader, num_tokens):
         """As suggested in Csiszarik et al (2020), we initialize the transformation
            matrix with pseudo inverse between activations
         """
@@ -50,8 +50,8 @@ class StitchNet(nn.Module):
         self._register_both_fw_hooks()
 
         # Save activations
-        act1 = torch.empty(0, 2, self.hidden_size).to(device)
-        act2 = torch.empty(0, 2, self.hidden_size).to(device)
+        act1 = torch.empty(0, num_tokens, self.hidden_size).to(device)
+        act2 = torch.empty(0, num_tokens, self.hidden_size).to(device)
 
         for batch in loader:
             _ = batch.pop('labels')
@@ -59,8 +59,8 @@ class StitchNet(nn.Module):
             with torch.no_grad():
                 self.front_model(**batch)
                 self.end_model(**batch)
-                act1 = torch.cat([act1, self.front_model.activation[:, :2]])
-                act2 = torch.cat([act2, self.end_model.activation[:, :2]])
+                act1 = torch.cat([act1, self.front_model.activation[:, :num_tokens]])
+                act2 = torch.cat([act2, self.end_model.activation[:, :num_tokens]])
 
             if len(act1) > 200:
                 break

--- a/utils/affine_stitch.py
+++ b/utils/affine_stitch.py
@@ -1,16 +1,26 @@
 import torch
 from torch import nn
 from copy import deepcopy
-from transformers import AutoModelForSequenceClassification
+from transformers import AutoModelForSequenceClassification, AutoModelForTokenClassification
+from data import WIKIANN_NAME
 
+def init_XML(checkpoint, id2label):
+    if WIKIANN_NAME in checkpoint:
+        label2id = {v: k for k, v in id2label.items()}
+        model = AutoModelForTokenClassification.from_pretrained(checkpoint, id2label=id2label, label2id=label2id) 
+    else: # sequence classification
+        model = AutoModelForSequenceClassification.from_pretrained(checkpoint)
+    return model
 
 class StitchNet(nn.Module):
 
-    def __init__(self, ckp1: str, ckp2: str, layer_idx: int):
+    def __init__(self, ckp1: str, ckp2: str, layer_idx: int, id2label: dict = None):
+        # The last label is only useful for NER so I added default None
         super().__init__()
         # Note: these models are in eval mode by default
-        self.front_model = AutoModelForSequenceClassification.from_pretrained(ckp1)
-        self.end_model = AutoModelForSequenceClassification.from_pretrained(ckp2)
+        self.front_model = init_XML(ckp1, id2label)
+        self.end_model = init_XML(ckp2, id2label)
+
         self.layer_idx = layer_idx
         self.hidden_size = self.front_model.config.hidden_size
         self.n_heads = self.front_model.config.num_attention_heads
@@ -40,19 +50,21 @@ class StitchNet(nn.Module):
         self._register_both_fw_hooks()
 
         # Save activations
-        act1 = torch.empty(0, 32, self.hidden_size).to(device)
-        act2 = torch.empty(0, 32, self.hidden_size).to(device)
+        act1 = torch.empty(0, 2, self.hidden_size).to(device)
+        act2 = torch.empty(0, 2, self.hidden_size).to(device)
+
         for batch in loader:
             _ = batch.pop('labels')
             batch = {k: v.to(device, non_blocking=True) for (k, v) in batch.items()}
             with torch.no_grad():
                 self.front_model(**batch)
                 self.end_model(**batch)
-                act1 = torch.cat([act1, self.front_model.activation[:, :32]])
-                act2 = torch.cat([act2, self.end_model.activation[:, :32]])
+                act1 = torch.cat([act1, self.front_model.activation[:, :2]])
+                act2 = torch.cat([act2, self.end_model.activation[:, :2]])
+
             if len(act1) > 200:
                 break
-
+            
         # Initialize weights
         optimal_w = self._pseudo_inverse(act1, act2)
         with torch.no_grad():
@@ -63,6 +75,8 @@ class StitchNet(nn.Module):
         self._register_default_hooks()
 
     def forward(self, *args, **kwargs):
+        # are labels here useful for NER since we have some with ignore index -100?
+        # probably not
         with torch.no_grad():
             # Note: leaving out label because number of classes might differ
             self.front_model(kwargs['input_ids'],


### PR DESCRIPTION
For the [initialization ](https://github.com/apostolikas/Language-Specific-Subnetworks/blob/stitching_NER/utils/affine_stitch.py#L53) of the stitch layers, some batches have max_seq_length < 32 so your initial code isn't working.
One naive way to fix this is to just find beforehand the min max_seq_length across all batches.

I am not sure I can understand why you compare based on the number of classes [here](https://github.com/apostolikas/Language-Specific-Subnetworks/blob/stitching_NER/stitch.py#L29). Is this intended behavior? I see that marc and Paws-x have the same number of classes.

For NER, labels can also have ignore id for the loss function. For the front model [here ](https://github.com/apostolikas/Language-Specific-Subnetworks/blob/stitching_NER/utils/affine_stitch.py#L82)you just take the activation so
again like the other tasks we would probably don't need to add the labels I guess.

maybe we can work with smaller n_samples for this task.